### PR TITLE
arrow 1.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,8 @@ test:
     - pytest-cov
     - pytest-mock
     - pytz
+    # the issue 'bad escape \d at position 7' started to happen after version 2022.3.15
+    - regex <2022.3.15
     - simplejson
   commands:
     - python -m pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.1" %}
+{% set version = "1.2.2" %}
 
 package:
   name: arrow
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/arrow/arrow-{{ version }}.tar.gz
-  sha256: dee7602f6c60e3ec510095b5e301441bc56288cb8f51def14dcb3079f623823a
+  sha256: 05caf1fd3d9a11a1135b2b6f09887421153b94558e5ef4d090b567b47173ac2b
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,8 @@ test:
     - simplejson
   commands:
     - python -m pip check
-    # 2022/4/5: skip tests on s390x as dateparser need to be updated
-    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz" # [not (linux and s390x)]
+    # 2022/4/5: tests on s390x fail because dateparser requires tzlocal bit it's currently not available on s390x 
+    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz"
 
 about:
   home: https://github.com/crsmithdev/arrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  skip: True  #[py<36]
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
@@ -20,9 +20,9 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python
+    - python >=3.6
     - python-dateutil >=2.7.0
-    - typing_extensions   #[py<38]
+    - typing_extensions
 
 test:
   source_files:
@@ -37,8 +37,7 @@ test:
     - simplejson
   commands:
     - python -m pip check
-    # 4/29/2012: Skip failed tests - shift_kiritimati on linux or ppc64le, and one_arg_dateparser_datetime on (win32 and py36) for 1.1.0
-    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz and not shift_kiritimati and not one_arg_dateparser_datetime"  # [linux or ppc64le or (win32 and py36)]
+    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz"
 
 about:
   home: https://github.com/crsmithdev/arrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,8 @@ test:
     - simplejson
   commands:
     - python -m pip check
-    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz"
+    # 2022/4/5: skip tests on s390x as dateparser need to be updated
+    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz" # [not (linux and s390x)]
 
 about:
   home: https://github.com/crsmithdev/arrow


### PR DESCRIPTION
Update arrow to 1.2.2

Changelog: https://github.com/arrow-py/arrow/blob/1.2.2/CHANGELOG.rst
License: https://github.com/arrow-py/arrow/blob/1.2.2/LICENSE
Requierements:
- https://github.com/arrow-py/arrow/blob/1.2.2/setup.py
- https://github.com/arrow-py/arrow/blob/1.2.2/requirements/requirements.txt
- https://github.com/arrow-py/arrow/blob/1.2.2/requirements/requirements-tests.txt

Actions:
1. Make n`oarch: python`
2. Fix the test issue with  `bad escape \d at position 7` started to happen after version `regex 2022.3.15`
3. Update test/commands