### PR TITLE
Update Arrow to v1.2.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,10 +33,10 @@ test:
     - pytest
     - pytest-cov
     - pytest-mock
-    - pytz
+    - pytz >=2021.1
     # the issue 'bad escape \d at position 7' started to happen after version 2022.3.15
     - regex <2022.3.15
-    - simplejson
+    - simplejson >=3.*
   commands:
     - python -m pip check
     # 2022/4/5: tests on s390x fail because dateparser requires tzlocal bit it's currently not available on s390x 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
   run:
     - python
     - python-dateutil >=2.7.0
-    - typing_extensions
+    - typing_extensions  #[py<38]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ test:
     - cd tests && pytest --cov arrow
 
 about:
-  home: https://github.com/crsmithdev/arrow
+  home: https://github.com/arrow-py/arrow
   license: Apache-2.0
   license_file: LICENSE
   license_family: Apache
@@ -56,9 +56,9 @@ about:
     and provides an intelligent module API that supports many common creation
     scenarios. Simply put, it helps you work with dates and times with fewer
     imports and a lot less code.
-  dev_url: https://github.com/crsmithdev/arrow
+  dev_url: https://github.com/arrow-py/arrow
   doc_url: https://arrow.readthedocs.io
-  doc_source_url: https://github.com/crsmithdev/arrow/tree/master/docs
+  doc_source_url: https://github.com/arrow-py/arrow/tree/master/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,6 +47,7 @@ about:
   license: Apache-2.0
   license_file: LICENSE
   license_family: Apache
+  license_url: https://github.com/arrow-py/arrow/blob/master/LICENSE
   summary: Better dates & times for Python
   description: |
     Arrow is a Python library that offers a sensible, human-friendly approach to

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,8 @@ test:
     - pytest-cov
     - pytest-mock
     - pytz
+    # the issue 'bad escape \d at position 7' started to happen after version 2022.3.15
+    - regex <2022.3.15
     - simplejson
   commands:
     - python -m pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  skip: True  #[py<36]
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
   run:
     - python
     - python-dateutil >=2.7.0
-    - typing_extensions  #[py<38]
+    - typing_extensions  # [py<38]
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,7 @@ test:
     - simplejson >=3.*
   commands:
     - python -m pip check
-    # 2022/4/5: tests on s390x fail because dateparser requires tzlocal bit it's currently not available on s390x 
-    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz"
+    - cd tests && pytest --cov arrow
 
 about:
   home: https://github.com/crsmithdev/arrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.1" %}
+{% set version = "1.2.2" %}
 
 package:
   name: arrow
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/arrow/arrow-{{ version }}.tar.gz
-  sha256: dee7602f6c60e3ec510095b5e301441bc56288cb8f51def14dcb3079f623823a
+  sha256: 05caf1fd3d9a11a1135b2b6f09887421153b94558e5ef4d090b567b47173ac2b
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  #[py<36]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -20,7 +20,7 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python >=3.6
+    - python
     - python-dateutil >=2.7.0
     - typing_extensions
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,8 @@ test:
     - pytest
     - pytest-cov
     - pytest-mock
-    - pytz >=2021.1
+    # Pin `pytz` to match upstream. Prevents chance for version mismatch with `python-dateutils`
+    - pytz ==2021.1
     # the issue 'bad escape \d at position 7' started to happen after version 2022.3.15
     - regex <2022.3.15
     - simplejson >=3.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.2" %}
+{% set version = "1.2.3" %}
 
 package:
   name: arrow
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/arrow/arrow-{{ version }}.tar.gz
-  sha256: 05caf1fd3d9a11a1135b2b6f09887421153b94558e5ef4d090b567b47173ac2b
+  sha256: 3934b30ca1b9f292376d9db15b19446088d12ec58629bc3f0da28fd55fb633a1
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,8 +39,8 @@ test:
     - simplejson
   commands:
     - python -m pip check
-    # 2022/4/5: skip tests on s390x as dateparser need to be updated
-    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz" # [not (linux and s390x)]
+    # 2022/4/5: tests on s390x fail because dateparser requires tzlocal bit it's currently not available on s390x 
+    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz"
 
 about:
   home: https://github.com/crsmithdev/arrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
 
 build:
   number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
-  skip: True  #[py<36]
+  noarch: python
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
@@ -20,9 +20,9 @@ requirements:
     - wheel
     - setuptools
   run:
-    - python
+    - python >=3.6
     - python-dateutil >=2.7.0
-    - typing_extensions   #[py<38]
+    - typing_extensions
 
 test:
   source_files:
@@ -37,8 +37,7 @@ test:
     - simplejson
   commands:
     - python -m pip check
-    # 4/29/2012: Skip failed tests - shift_kiritimati on linux or ppc64le, and one_arg_dateparser_datetime on (win32 and py36) for 1.1.0
-    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz and not shift_kiritimati and not one_arg_dateparser_datetime"  # [linux or ppc64le or (win32 and py36)]
+    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz"
 
 about:
   home: https://github.com/crsmithdev/arrow

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,8 @@ test:
     - simplejson
   commands:
     - python -m pip check
-    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz"
+    # 2022/4/5: skip tests on s390x as dateparser need to be updated
+    - cd tests && pytest --cov arrow -k "not parse_tz_name_zzz" # [not (linux and s390x)]
 
 about:
   home: https://github.com/crsmithdev/arrow


### PR DESCRIPTION
# Update Arrow to v1.2.3

- Update version and SHA256
- Revert noarch build
- Update pinnings for  `pytz ==2021.1` and `simplejson >=3.*` to match [upstream](https://github.com/arrow-py/arrow/blob/1.2.3/requirements/requirements-tests.txt)
- Add missing `license_url`